### PR TITLE
Fixed infinite loop in defaultExtractor

### DIFF
--- a/src/LTDBeget/dns/record/RData.php
+++ b/src/LTDBeget/dns/record/RData.php
@@ -203,6 +203,7 @@ class RData
                     $this->stream->next();
                     if($this->stream->isEnd()) {
                         $this->tokens[$tokenName] = trim($this->tokens[$tokenName]);
+                        return;
                     }
                     goto start;
                 }


### PR DESCRIPTION
I'm not sure why and I suspect that the real bug is in the StringStream class but I tried parsing a zone from a string and the script would just hang until it timed out.

By adding some basic debug output I could figure out that it was looping at the last token (a `.` in my case) without ever advancing to a LINE_FEED or NULL that would return from the function.

Whatever the reason it seems like a good failsafe to add a return inside the `stream->isEnd()` branch.